### PR TITLE
register pysubs2 to path && use setuptools when available

### DIFF
--- a/pysubs2/cli.py
+++ b/pysubs2/cli.py
@@ -163,3 +163,13 @@ class Pysubs2CLI(object):
         elif args.transform_framerate is not None:
             in_fps, out_fps = args.transform_framerate
             subs.transform_framerate(in_fps, out_fps)
+
+
+def __main__():
+    cli = Pysubs2CLI()
+    rv = cli(sys.argv[1:])
+    sys.exit(rv)
+
+
+if __name__ == "__main__":
+    __main__()

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from distutils.core import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 from textwrap import dedent
 from pysubs2 import VERSION
 
@@ -48,4 +51,5 @@ setup(
         "Operating System :: OS Independent",
         "License :: OSI Approved :: MIT License"
         ],
+    entry_points={'console_scripts': ['pysubs2 = pysubs2.cli:__main__']}
     )


### PR DESCRIPTION
Little change that allows using pysubs like a program instead of python library:
```bash
$ pip install pysubs2
$ pysubs2 --shift 0.3s *.srt
$ pysubs2 --to srt *.ass
```