### PR TITLE
Support negative timestamps for Substation files

### DIFF
--- a/pysubs2/time.py
+++ b/pysubs2/time.py
@@ -5,7 +5,7 @@ import re
 
 
 #: Pattern that matches both SubStation and SubRip timestamps.
-TIMESTAMP = re.compile(r"(\d{1,2}):(\d{2}):(\d{2})[.,](\d{2,3})")
+TIMESTAMP = re.compile(r"(-?\d{1,2}):(\d{2}):(\d{2})[.,](\d{2,3})")
 
 Times = namedtuple("Times", ["h", "m", "s", "ms"])
 


### PR DESCRIPTION
Title and diff say it all. Test input where it was previously crashing, and no longer does:

```
Dialogue: 0,-1:59:59.90,0:00:01.90,jp,,0000,0000,0000,,
```

Never mind, tests not passing. Let me fix that first.