### PR TITLE
Tmp subtitle format support

### DIFF
--- a/pysubs2/common.py
+++ b/pysubs2/common.py
@@ -17,7 +17,7 @@ class Color(_Color):
         return _Color.__new__(cls, r, g, b, a)
 
 #: Version of the pysubs2 library.
-VERSION = "0.2.2"
+VERSION = "0.2.3"
 
 
 PY3 = sys.version_info.major == 3

--- a/pysubs2/formats.py
+++ b/pysubs2/formats.py
@@ -4,6 +4,7 @@ from .subrip import SubripFormat
 from .jsonformat import JSONFormat
 from .substation import SubstationFormat
 from .mpl2 import MPL2Format
+from .tmp import TmpFormat
 from .exceptions import *
 
 #: Dict mapping file extensions to format identifiers.
@@ -13,6 +14,7 @@ FILE_EXTENSION_TO_FORMAT_IDENTIFIER = {
     ".ssa": "ssa",
     ".sub": "microdvd",
     ".json": "json",
+    ".txt": "tmp",
 }
 
 #: Dict mapping format identifiers to implementations (FormatBase subclasses).
@@ -23,6 +25,7 @@ FORMAT_IDENTIFIER_TO_FORMAT_CLASS = {
     "microdvd": MicroDVDFormat,
     "json": JSONFormat,
     "mpl2": MPL2Format,
+    "tmp": TmpFormat,
 }
 
 def get_format_class(format_):

--- a/pysubs2/time.py
+++ b/pysubs2/time.py
@@ -49,6 +49,20 @@ def timestamp_to_ms(groups):
     ms += h * 3600000
     return ms
 
+def tmptimestamp_to_ms(groups):
+    """
+    Convert groups from :data:`pysubs2.time.TMPTIMESTAMP` match to milliseconds.
+    
+    Example:
+        >>> timestamp_to_ms(TIMESTAMP.match("0:00:01").groups())
+        1000
+    
+    """
+    h, m, s  = map(int, groups)
+    ms = s * 1000
+    ms += m * 60000
+    ms += h * 3600000
+    return ms
 def times_to_ms(h=0, m=0, s=0, ms=0):
     """
     Convert hours, minutes, seconds to milliseconds.

--- a/pysubs2/tmp.py
+++ b/pysubs2/tmp.py
@@ -1,0 +1,88 @@
+from __future__ import print_function, unicode_literals
+
+import re
+from .formatbase import FormatBase
+from .ssaevent import SSAEvent
+from .ssastyle import SSAStyle
+from .substation import parse_tags
+from .time import ms_to_times, make_time, tmptimestamp_to_ms 
+
+#: Pattern that matches TMP timestamp
+TMPTIMESTAMP = re.compile(r"(\d{1,2}):(\d{2}):(\d{2})")
+#: Pattern that matches TMP line
+TMP_LINE = re.compile(r"(\d{1,2}:\d{2}:\d{2}):(.+)")
+
+#: Largest timestamp allowed in Tmp, ie. 99:59:59.
+MAX_REPRESENTABLE_TIME = make_time(h=100) - 1
+
+def ms_to_timestamp(ms):
+    """Convert ms to 'HH:MM:SS'"""
+    # XXX throw on overflow/underflow?
+    if ms < 0: ms = 0
+    if ms > MAX_REPRESENTABLE_TIME: ms = MAX_REPRESENTABLE_TIME
+    h, m, s, ms = ms_to_times(ms)
+    return "%02d:%02d:%02d" % (h, m, s)
+
+
+class TmpFormat(FormatBase):
+    @classmethod
+    def guess_format(cls, text):
+        if "[Script Info]" in text or "[V4+ Styles]" in text:
+            # disambiguation vs. SSA/ASS
+            return None
+
+        for line in text.splitlines():
+            if len(TMP_LINE.findall(line)) == 1:
+                return "tmp"
+
+    @classmethod
+    def from_file(cls, subs, fp, format_, **kwargs):
+        timestamps = [] # (start)
+        lines = [] # contains lists of lines following each timestamp
+
+        for line in fp:
+            match = TMP_LINE.match(line)
+            if not match:
+                continue
+
+            start, text = match.groups()
+            start = tmptimestamp_to_ms(TMPTIMESTAMP.match(start).groups())
+            #calculate endtime from starttime + 3 seconds + 0.5 second per each space in string (which should roughly equal number of words)
+            end = start + 3000 + (500 * line.count(" "))
+            timestamps.append((start, end))
+            lines.append(text)
+
+        def prepare_text(lines):
+            lines = lines.replace("|", r"\N")  # convert newlines
+            lines = re.sub(r"< *u *>", "{\\u1}", lines) # not r" for Python 2.7 compat, triggers unicodeescape
+            lines = re.sub(r"< */? *[a-zA-Z][^>]*>", "", lines) # strip other HTML tags
+            return lines
+
+        subs.events = [SSAEvent(start=start, end=end, text=prepare_text(lines))
+                       for (start, end), lines in zip(timestamps, lines)]
+
+    @classmethod
+    def to_file(cls, subs, fp, format_, **kwargs):
+        def prepare_text(text, style):
+            body = []
+            for fragment, sty in parse_tags(text, style, subs.styles):
+                fragment = fragment.replace(r"\h", " ")
+                fragment = fragment.replace(r"\n", "\n")
+                fragment = fragment.replace(r"\N", "\n")
+                if sty.italic: fragment = "<i>%s</i>" % fragment
+                if sty.underline: fragment = "<u>%s</u>" % fragment
+                if sty.strikeout: fragment = "<s>%s</s>" % fragment
+                body.append(fragment)
+
+            return re.sub("\n+", "\n", "".join(body).strip())
+
+        visible_lines = (line for line in subs if not line.is_comment)
+
+        for i, line in enumerate(visible_lines, 1):
+            start = ms_to_timestamp(line.start)
+            #end = ms_to_timestamp(line.end)
+            text = prepare_text(line.text, subs.styles.get(line.style, SSAStyle.DEFAULT_STYLE))
+
+            print("%d" % i, file=fp) # Python 2.7 compat
+            print(start, text, end="\n", file=fp)
+            #print(text, end="\n\n", file=fp)

--- a/pysubs2/tmp.py
+++ b/pysubs2/tmp.py
@@ -47,8 +47,8 @@ class TmpFormat(FormatBase):
 
             start, text = match.groups()
             start = tmptimestamp_to_ms(TMPTIMESTAMP.match(start).groups())
-            #calculate endtime from starttime + 2 seconds + 0.4 second per each space in string (which should roughly equal number of words)
-            end = start + 2000 + (400 * line.count(" "))
+            #calculate endtime from starttime + 500 miliseconds + 67 miliseconds per each character (15 chars per second)
+            end = start + 500 + (len(line) * 67)
             timestamps.append((start, end))
             lines.append(text)
 

--- a/pysubs2/tmp.py
+++ b/pysubs2/tmp.py
@@ -5,7 +5,7 @@ from .formatbase import FormatBase
 from .ssaevent import SSAEvent
 from .ssastyle import SSAStyle
 from .substation import parse_tags
-from .time import ms_to_times, make_time, tmptimestamp_to_ms 
+from .time import ms_to_times, make_time, tmptimestamp_to_ms
 
 #: Pattern that matches TMP timestamp
 TMPTIMESTAMP = re.compile(r"(\d{1,2}):(\d{2}):(\d{2})")
@@ -83,6 +83,6 @@ class TmpFormat(FormatBase):
             #end = ms_to_timestamp(line.end)
             text = prepare_text(line.text, subs.styles.get(line.style, SSAStyle.DEFAULT_STYLE))
 
-            print("%d" % i, file=fp) # Python 2.7 compat
-            print(start, text, end="\n", file=fp)
+            #print("%d" % i, file=fp) # Python 2.7 compat
+            print(start + ":" + text, end="\n", file=fp)
             #print(text, end="\n\n", file=fp)

--- a/pysubs2/tmp.py
+++ b/pysubs2/tmp.py
@@ -47,8 +47,8 @@ class TmpFormat(FormatBase):
 
             start, text = match.groups()
             start = tmptimestamp_to_ms(TMPTIMESTAMP.match(start).groups())
-            #calculate endtime from starttime + 3 seconds + 0.5 second per each space in string (which should roughly equal number of words)
-            end = start + 3000 + (500 * line.count(" "))
+            #calculate endtime from starttime + 2 seconds + 0.4 second per each space in string (which should roughly equal number of words)
+            end = start + 2000 + (400 * line.count(" "))
             timestamps.append((start, end))
             lines.append(text)
 

--- a/tests/test_tmp.py
+++ b/tests/test_tmp.py
@@ -1,0 +1,56 @@
+"""
+pysubs2.formats.tmp tests
+
+"""
+
+from __future__ import unicode_literals
+from textwrap import dedent
+from pysubs2 import SSAFile, SSAEvent, make_time
+
+def test_simple_write():
+    subs = SSAFile()
+
+    e1 = SSAEvent()
+    e1.start = 0
+    e1.end = 60000
+    e1.text = "ten--chars"
+
+    e2 = SSAEvent()
+    e2.start = 60000
+    e2.end = 120000
+    e2.text = "ten--chars-ten-chars"
+
+    e3 = SSAEvent()
+    e3.start = 60000
+    e3.end = 120000
+    e3.text = "Invisible subtitle."
+    e3.is_comment = True
+
+    subs.append(e1)
+    subs.append(e2)
+    subs.append(e3)
+
+    ref = dedent("""\
+    00:00:00:ten--chars
+    00:01:00:ten--chars-ten-chars
+    """)
+
+    text = subs.to_string("tmp")
+    assert text.strip() == ref.strip()
+
+
+def test_simple_read():
+    text = dedent("""\
+    00:00:00:ten--chars
+    00:01:00:ten--chars-ten-chars
+    """)
+    #calculate endtime from starttime + 500 miliseconds + 67 miliseconds per each character (15 chars per second)
+    ref = SSAFile()
+    ref.append(SSAEvent(start=0, end=make_time(ms=1840), text="ten--chars"))
+    ref.append(SSAEvent(start=make_time(m=1), end=make_time(ms=62510), text="ten--chars-ten-chars"))
+
+    subs = SSAFile.from_string(text)
+    assert subs.equals(ref)
+
+
+


### PR DESCRIPTION
.tmp format is an old one but can still be found, especially for old movies. 
It is a single line format having only a start time:
00:05:22:This is a subtitle text