### PR TITLE
Change depreciated unknown escapes in subrip.py for compatibility with python 3.7

### DIFF
--- a/pysubs2/subrip.py
+++ b/pysubs2/subrip.py
@@ -56,14 +56,14 @@ class SubripFormat(FormatBase):
             # Handle the general case.
             s = "".join(lines).strip()
             s = re.sub(r"\n+ *\d+ *$", "", s) # strip number of next subtitle
-            s = re.sub(r"< *i *>", r"{\i1}", s)
-            s = re.sub(r"< */ *i *>", r"{\i0}", s)
-            s = re.sub(r"< *s *>", r"{\s1}", s)
-            s = re.sub(r"< */ *s *>", r"{\s0}", s)
-            s = re.sub(r"< *u *>", "{\\u1}", s) # not r" for Python 2.7 compat, triggers unicodeescape
-            s = re.sub(r"< */ *u *>", "{\\u0}", s)
+            s = re.sub(r"< *i *>", r"{\\i1}", s)
+            s = re.sub(r"< */ *i *>", r"{\\i0}", s)
+            s = re.sub(r"< *s *>", r"{\\s1}", s)
+            s = re.sub(r"< */ *s *>", r"{\\s0}", s)
+            s = re.sub(r"< *u *>", "{\\\\u1}", s) # not r" for Python 2.7 compat, triggers unicodeescape
+            s = re.sub(r"< */ *u *>", "{\\\\u0}", s)
             s = re.sub(r"< */? *[a-zA-Z][^>]*>", "", s) # strip other HTML tags
-            s = re.sub(r"\n", r"\N", s) # convert newlines
+            s = re.sub(r"\n", r"\\N", s) # convert newlines
             return s
 
         subs.events = [SSAEvent(start=start, end=end, text=prepare_text(lines))


### PR DESCRIPTION
Fixes https://github.com/tkarabela/pysubs2/issues/23
See https://docs.python.org/3.7/library/re.html#re.sub
>Changed in version 3.7: Unknown escapes in repl consisting of '\' and an ASCII letter now are errors.