### PR TITLE
Add more flexibility in timestamps for substation files

### DIFF
--- a/pysubs2/time.py
+++ b/pysubs2/time.py
@@ -4,7 +4,7 @@ from typing import Optional, List, Tuple, Sequence
 from pysubs2.common import IntOrFloat
 
 #: Pattern that matches both SubStation and SubRip timestamps.
-TIMESTAMP = re.compile(r"(\d{1,2}):(\d{2}):(\d{2})[.,](\d{2,3})")
+TIMESTAMP = re.compile(r"(\d{1,2}):(\d{1,2}):(\d{1,2})[.,](\d{1,3})")
 
 #: Pattern that matches H:MM:SS or HH:MM:SS timestamps.
 TIMESTAMP_SHORT = re.compile(r"(\d{1,2}):(\d{2}):(\d{2})")


### PR DESCRIPTION
This PR makes the regular expression for timestamps more flexible for substation files to support timestamps formatted as H:M:S:m (skipping leading zeroes) which arguably is bad formatting but still renders fine through libass.

Example file that uses this timestamp format: https://kara.moe/downloads/lyrics/JPN%20-%20Aikatsu!%20Idol%20Katsudou!%20-%20ED1%20-%20Calendar%20Girl.ass