### PR TITLE
PoC SRT color and alignment

### DIFF
--- a/pysubs2/subrip.py
+++ b/pysubs2/subrip.py
@@ -142,6 +142,14 @@ class SubripFormat(FormatBase):
                         if sty.italic: fragment = "<i>%s</i>" % fragment
                         if sty.underline: fragment = "<u>%s</u>" % fragment
                         if sty.strikeout: fragment = "<s>%s</s>" % fragment
+
+                        # sty.primarycolor and sty.alignment has some value instead of None,
+                        # so comparision to default is needed to omit unnecessary tags...
+                        if sty.primarycolor !=  SSAStyle.DEFAULT_STYLE.primarycolor:
+                            hex_color = "%02x%02x%02x" % (sty.primarycolor.r, sty.primarycolor.g, sty.primarycolor.b)
+                            fragment = f'<font color=#{hex_color}>{fragment}</font>'
+                        if sty.alignment != SSAStyle.DEFAULT_STYLE.alignment:
+                            fragment = "{\\an%s}%s" % (sty.alignment, fragment)
                     if sty.drawing: raise ContentNotUsable
                     body.append(fragment)
 


### PR DESCRIPTION
Hi

After generating text using openai whisper, mutlilingual encoders and stuff, I was trying to actually merge two subtitles using this library, to accelerate my language learning.
So I've implemented text color and alignment for srt, for example:

![x](https://user-images.githubusercontent.com/4583553/204109187-65cff4d3-c461-4958-82d0-668fd144cedd.png)

In the end, I found that I could use SSA/ASS as it works out of the box, but anyway 😆

as `pysubs2` documentation says:
> SubRip (SRT)
> it uses HTML tags for formatting

Do you think it is valuable to add such formatting? This is just a proof of concept, but it could be worked out if accepted

End result looks like on the screenshot (it is from vlc)


There is no specs of srt format, here I found some refs:
- https://docs.lokalise.com/en/articles/5365539-subrip-srt
- https://forum.doom9.org/showthread.php?p=470941#post470941
- https://forum.videolan.org/viewtopic.php?f=7&t=49774