### PR TITLE
Treat any number that is not equal to 0 as True

### DIFF
--- a/pysubs2/substation.py
+++ b/pysubs2/substation.py
@@ -199,7 +199,7 @@ class SubstationFormat(FormatBase):
                 v = v.strip()
                 return rgba_to_color(v)
             elif f in {"bold", "underline", "italic", "strikeout"}:
-                return v == "-1"
+                return bool(int(v))
             elif f in {"borderstyle", "encoding", "marginl", "marginr", "marginv", "layer", "alphalevel"}:
                 return int(v)
             elif f in {"fontsize", "scalex", "scaley", "spacing", "angle", "outline", "shadow"}:


### PR DESCRIPTION
I found subtitles created in somewhere in 2009 by unknown program that use "1" instead of "-1" as the True value. When I open such subtitles using pysubs2, the values of bool, italic, etc are lost. Video players display such subtitles correctly.

```
[V4+ Styles]
Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
Style: Default,Arial,42,&H0000FFFF,&H0000FFFF,&H00000000,&H00000000,1,0,0,0,100,100,0,0,1,2,0,2,20,20,5,204
Style: Default-alt,Arial,42,&H0000FFFF,&H0000FFFF,&H00000000,&H00000000,1,1,0,0,100,100,0,0,1,2,0,2,20,20,5,204
Style: Notes,Palatino Linotype,60,&H000E0B0C,&H000E0B0C,&H00FAF7F2,&H00FAF7F2,1,1,0,0,100,100,0,0,1,2,0,2,20,20,5,204
```