### PR TITLE
use bytestrings

### DIFF
--- a/pysubs2/cli.py
+++ b/pysubs2/cli.py
@@ -31,7 +31,7 @@ def character_encoding(s: str) -> str:
 
 def time(s: str) -> int:
     d = {}
-    for v, k in re.findall(r"(\d*\.?\d*)(ms|m|s|h)", s):
+    for v, k in re.findall(rb"(\d*\.?\d*)(ms|m|s|h)", s):
         d[k] = float(v)
     return make_time(**d)  # type: ignore  # Argument 1 has incomp. type "**Dict[Any, float]"; expected "Optional[int]"
 

--- a/pysubs2/jsonformat.py
+++ b/pysubs2/jsonformat.py
@@ -24,7 +24,7 @@ class JSONFormat(FormatBase):
     @classmethod
     def guess_format(cls, text):
         """See :meth:`pysubs2.formats.FormatBase.guess_format()`"""
-        if text.startswith("{\""):
+        if text.startswith(b"{\""):
             return "json"
 
     @classmethod
@@ -39,7 +39,7 @@ class JSONFormat(FormatBase):
         for name, fields in data["styles"].items():
             subs.styles[name] = sty = SSAStyle()
             for k, v in fields.items():
-                if "color" in k:
+                if b"color" in k:
                     setattr(sty, k, Color(**v))
                 else:
                     setattr(sty, k, v)

--- a/pysubs2/microdvd.py
+++ b/pysubs2/microdvd.py
@@ -20,7 +20,7 @@ class MicroDVDFormat(FormatBase):
             return "microdvd"
 
     @classmethod
-    def from_file(cls, subs, fp, format_, fps=None, **kwargs):
+    def from_file(cls, subs, fp, format_, fps=None, keep_style_tags=False, **kwargs):
         """See :meth:`pysubs2.formats.FormatBase.from_file()`"""
         for line in fp:
             match = MICRODVD_LINE.match(line)
@@ -47,6 +47,9 @@ class MicroDVDFormat(FormatBase):
 
             def prepare_text(text):
                 text = text.replace(b"|", rb"\N")
+
+                if keep_style_tags:
+                    return text.strip()
 
                 def style_replacer(match: re.Match) -> str:
                     tags = [c for c in b"biu" if c in match.group(0)]

--- a/pysubs2/mpl2.py
+++ b/pysubs2/mpl2.py
@@ -6,7 +6,7 @@ from .ssaevent import SSAEvent
 
 
 # thanks to http://otsaloma.io/gaupol/doc/api/aeidon.files.mpl2_source.html
-MPL2_FORMAT = re.compile(r"^\[(-?\d+)\]\[(-?\d+)\](.*)", re.MULTILINE)
+MPL2_FORMAT = re.compile(rb"^\[(-?\d+)\]\[(-?\d+)\](.*)", re.MULTILINE)
 
 
 class MPL2Format(FormatBase):
@@ -22,15 +22,15 @@ class MPL2Format(FormatBase):
         """See :meth:`pysubs2.formats.FormatBase.from_file()`"""
         def prepare_text(lines):
             out = []
-            for s in lines.split("|"):
+            for s in lines.split(b"|"):
                 s = s.strip()
 
-                if s.startswith("/"):
+                if s.startswith(b"/"):
                     # line beginning with '/' is in italics
-                    s = r"{\i1}%s{\i0}" % s[1:].strip()
+                    s = rb"{\i1}%s{\i0}" % s[1:].strip()
 
                 out.append(s)
-            return "\\N".join(out)
+            return b"\\N".join(out)
 
         subs.events = [SSAEvent(start=times_to_ms(s=float(start) / 10), end=times_to_ms(s=float(end) / 10),
                        text=prepare_text(text)) for start, end, text in MPL2_FORMAT.findall(fp.getvalue())]
@@ -48,7 +48,7 @@ class MPL2Format(FormatBase):
             if line.is_comment:
                 continue
 
-            print("[{start}][{end}] {text}".format(start=int(line.start // 100),
+            print(b"[{start}][{end}] {text}".format(start=int(line.start // 100),
                                                    end=int(line.end // 100),
-                                                   text=line.plaintext.replace("\n", "|")),
+                                                   text=line.plaintext.replace(b"\n", b"|")),
                   file=fp)

--- a/pysubs2/ssaevent.py
+++ b/pysubs2/ssaevent.py
@@ -25,19 +25,19 @@ class SSAEvent:
         >>> ev = SSAEvent(start=make_time(s=1), end=make_time(s=2.5), text="Hello World!")
 
     """
-    OVERRIDE_SEQUENCE: ClassVar = re.compile(r"{[^}]*}")
+    OVERRIDE_SEQUENCE: ClassVar = re.compile(rb"{[^}]*}")
 
     start: int = 0  #: Subtitle start time (in milliseconds)
     end: int = 10000  #: Subtitle end time (in milliseconds)
-    text: str = ""  #: Text of subtitle (with SubStation override tags)
+    text: bytes = b""  #: Text of subtitle (with SubStation override tags)
     marked: bool = False  #: (SSA only)
     layer: int = 0  #: Layer number, 0 is the lowest layer (ASS only)
-    style: str = "Default"  #: Style name
-    name: str = ""  #: Actor name
+    style: bytes = b"Default"  #: Style name
+    name: bytes = b""  #: Actor name
     marginl: int = 0  #: Left margin
     marginr: int = 0  #: Right margin
     marginv: int = 0  #: Vertical margin
-    effect: str = ""  #: Line effect
+    effect: bytes = b""  #: Line effect
     type: str = "Dialogue"  #: Line type (Dialogue/Comment)
 
     @property
@@ -96,14 +96,14 @@ class SSAEvent:
         """
         text = self.text
         text = self.OVERRIDE_SEQUENCE.sub("", text)
-        text = text.replace(r"\h", " ")
-        text = text.replace(r"\n", "\n")
-        text = text.replace(r"\N", "\n")
+        text = text.replace(rb"\h", b" ")
+        text = text.replace(rb"\n", b"\n")
+        text = text.replace(rb"\N", b"\n")
         return text
 
     @plaintext.setter
     def plaintext(self, text: str):
-        self.text = text.replace("\n", r"\N")
+        self.text = text.replace(b"\n", rb"\N")
 
     def shift(self, h: IntOrFloat=0, m: IntOrFloat=0, s: IntOrFloat=0, ms: IntOrFloat=0,
               frames: Optional[int]=None, fps: Optional[float]=None):

--- a/pysubs2/subrip.py
+++ b/pysubs2/subrip.py
@@ -49,7 +49,7 @@ class SubripFormat(FormatBase):
                 return "srt"
 
     @classmethod
-    def from_file(cls, subs, fp, format_, keep_html_tags=False, keep_unknown_html_tags=False, keep_newlines=False, **kwargs):
+    def from_file(cls, subs, fp, format_, keep_html_tags=False, keep_unknown_html_tags=False, keep_newlines=False, keep_original_newlines=False, **kwargs):
         """
         See :meth:`pysubs2.formats.FormatBase.from_file()`
 
@@ -93,6 +93,11 @@ class SubripFormat(FormatBase):
 
             # Handle the general case.
             s = b"".join(lines).strip()
+            if not keep_original_newlines:
+                # reading file to bytestring preserves the original line endings
+                # convert to unix line endings
+                s = re.sub(rb"\r\n", rb"\n", s)
+                s = re.sub(rb"\r", rb"\n", s)
             s = re.sub(rb"\n+ *\d+ *$", b"", s) # strip number of next subtitle
             if not keep_html_tags:
                 s = re.sub(rb"< *i *>", rb"{\\i1}", s)

--- a/pysubs2/subrip.py
+++ b/pysubs2/subrip.py
@@ -36,11 +36,11 @@ class SubripFormat(FormatBase):
     @classmethod
     def guess_format(cls, text):
         """See :meth:`pysubs2.formats.FormatBase.guess_format()`"""
-        if "[Script Info]" in text or "[V4+ Styles]" in text:
+        if b"[Script Info]" in text or b"[V4+ Styles]" in text:
             # disambiguation vs. SSA/ASS
             return None
 
-        if text.lstrip().startswith("WEBVTT"):
+        if text.lstrip().startswith(b"WEBVTT"):
             # disambiguation vs. WebVTT
             return None
 
@@ -87,25 +87,25 @@ class SubripFormat(FormatBase):
             # Handle the "happy" empty subtitle case, which is timestamp line followed by blank line(s)
             # followed by number line and timestamp line of the next subtitle. Fixes issue #11.
             if (len(lines) >= 2
-                    and all(re.match(r"\s*$", line) for line in lines[:-1])
-                    and re.match(r"\s*\d+\s*$", lines[-1])):
-                return ""
+                    and all(re.match(rb"\s*$", line) for line in lines[:-1])
+                    and re.match(rb"\s*\d+\s*$", lines[-1])):
+                return b""
 
             # Handle the general case.
-            s = "".join(lines).strip()
-            s = re.sub(r"\n+ *\d+ *$", "", s) # strip number of next subtitle
+            s = b"".join(lines).strip()
+            s = re.sub(rb"\n+ *\d+ *$", b"", s) # strip number of next subtitle
             if not keep_html_tags:
-                s = re.sub(r"< *i *>", r"{\\i1}", s)
-                s = re.sub(r"< */ *i *>", r"{\\i0}", s)
-                s = re.sub(r"< *s *>", r"{\\s1}", s)
-                s = re.sub(r"< */ *s *>", r"{\\s0}", s)
-                s = re.sub(r"< *u *>", r"{\\u1}", s)
-                s = re.sub(r"< */ *u *>", r"{\\u0}", s)
-                s = re.sub(r"< *b *>", r"{\\b1}", s)
-                s = re.sub(r"< */ *b *>", r"{\\b0}", s)
+                s = re.sub(rb"< *i *>", rb"{\\i1}", s)
+                s = re.sub(rb"< */ *i *>", rb"{\\i0}", s)
+                s = re.sub(rb"< *s *>", rb"{\\s1}", s)
+                s = re.sub(rb"< */ *s *>", rb"{\\s0}", s)
+                s = re.sub(rb"< *u *>", rb"{\\u1}", s)
+                s = re.sub(rb"< */ *u *>", rb"{\\u0}", s)
+                s = re.sub(rb"< *b *>", rb"{\\b1}", s)
+                s = re.sub(rb"< */ *b *>", rb"{\\b0}", s)
             if not (keep_html_tags or keep_unknown_html_tags):
-                s = re.sub(r"< */? *[a-zA-Z][^>]*>", "", s) # strip other HTML tags
-            s = re.sub(r"\n", r"\\N", s) # convert newlines
+                s = re.sub(rb"< */? *[a-zA-Z][^>]*>", b"", s) # strip other HTML tags
+            s = re.sub(rb"\n", rb"\\N", s) # convert newlines
             return s
 
         subs.events = [SSAEvent(start=start, end=end, text=prepare_text(lines))
@@ -134,10 +134,10 @@ class SubripFormat(FormatBase):
                 is SRT which doesn't use line styles - this shouldn't be much
                 of an issue in practice.)
         """
-        def prepare_text(text: str, style: SSAStyle):
-            text = text.replace(r"\h", " ")
-            text = text.replace(r"\n", "\n")
-            text = text.replace(r"\N", "\n")
+        def prepare_text(text: bytes, style: SSAStyle):
+            text = text.replace(rb"\h", b" ")
+            text = text.replace(rb"\n", b"\n")
+            text = text.replace(rb"\N", b"\n")
 
             body = []
             if keep_ssa_tags:
@@ -145,13 +145,13 @@ class SubripFormat(FormatBase):
             else:
                 for fragment, sty in parse_tags(text, style, subs.styles):
                     if apply_styles:
-                        if sty.italic: fragment = f"<i>{fragment}</i>"
-                        if sty.underline: fragment = f"<u>{fragment}</u>"
-                        if sty.strikeout: fragment = f"<s>{fragment}</s>"
+                        if sty.italic: fragment = b"<i>" + fragment + b"</i>"
+                        if sty.underline: fragment = b"<u>" + fragment + b"</u>"
+                        if sty.strikeout: fragment = b"<s>" + fragment + b"</s>"
                     if sty.drawing: raise ContentNotUsable
                     body.append(fragment)
 
-            return re.sub("\n+", "\n", "".join(body).strip())
+            return re.sub(b"\n+", b"\n", b"".join(body).strip())
 
         visible_lines = cls._get_visible_lines(subs)
 

--- a/pysubs2/subrip.py
+++ b/pysubs2/subrip.py
@@ -49,7 +49,7 @@ class SubripFormat(FormatBase):
                 return "srt"
 
     @classmethod
-    def from_file(cls, subs, fp, format_, keep_html_tags=False, keep_unknown_html_tags=False, **kwargs):
+    def from_file(cls, subs, fp, format_, keep_html_tags=False, keep_unknown_html_tags=False, keep_newlines=False, **kwargs):
         """
         See :meth:`pysubs2.formats.FormatBase.from_file()`
 
@@ -105,7 +105,8 @@ class SubripFormat(FormatBase):
                 s = re.sub(rb"< */ *b *>", rb"{\\b0}", s)
             if not (keep_html_tags or keep_unknown_html_tags):
                 s = re.sub(rb"< */? *[a-zA-Z][^>]*>", b"", s) # strip other HTML tags
-            s = re.sub(rb"\n", rb"\\N", s) # convert newlines
+            if not keep_newlines:
+                s = re.sub(rb"\n", rb"\\N", s) # convert newlines
             return s
 
         subs.events = [SSAEvent(start=start, end=end, text=prepare_text(lines))

--- a/pysubs2/time.py
+++ b/pysubs2/time.py
@@ -4,10 +4,10 @@ from typing import Optional, List, Tuple, Sequence
 from pysubs2.common import IntOrFloat
 
 #: Pattern that matches both SubStation and SubRip timestamps.
-TIMESTAMP = re.compile(r"(\d{1,2}):(\d{1,2}):(\d{1,2})[.,](\d{1,3})")
+TIMESTAMP = re.compile(rb"(\d{1,2}):(\d{1,2}):(\d{1,2})[.,](\d{1,3})")
 
 #: Pattern that matches H:MM:SS or HH:MM:SS timestamps.
-TIMESTAMP_SHORT = re.compile(r"(\d{1,2}):(\d{2}):(\d{2})")
+TIMESTAMP_SHORT = re.compile(rb"(\d{1,2}):(\d{2}):(\d{2})")
 
 Times = namedtuple("Times", ["h", "m", "s", "ms"])
 
@@ -44,9 +44,9 @@ def timestamp_to_ms(groups: Sequence[str]):
     match to milliseconds.
     
     Example:
-        >>> timestamp_to_ms(TIMESTAMP.match("0:00:00.42").groups())
+        >>> timestamp_to_ms(TIMESTAMP.match(b"0:00:00.42").groups())
         420
-        >>> timestamp_to_ms(TIMESTAMP_SHORT.match("0:00:01").groups())
+        >>> timestamp_to_ms(TIMESTAMP_SHORT.match(b"0:00:01").groups())
         1000
 
     """

--- a/pysubs2/tmp.py
+++ b/pysubs2/tmp.py
@@ -8,7 +8,7 @@ from .substation import parse_tags
 from .time import ms_to_times, make_time, TIMESTAMP_SHORT, timestamp_to_ms
 
 #: Pattern that matches TMP line
-TMP_LINE = re.compile(r"(\d{1,2}:\d{2}:\d{2}):(.+)")
+TMP_LINE = re.compile(rb"(\d{1,2}:\d{2}:\d{2}):(.+)")
 
 #: Largest timestamp allowed in Tmp, ie. 99:59:59.
 MAX_REPRESENTABLE_TIME = make_time(h=99, m=59, s=59)
@@ -31,7 +31,7 @@ class TmpFormat(FormatBase):
     @classmethod
     def guess_format(cls, text):
         """See :meth:`pysubs2.formats.FormatBase.guess_format()`"""
-        if "[Script Info]" in text or "[V4+ Styles]" in text:
+        if b"[Script Info]" in text or b"[V4+ Styles]" in text:
             # disambiguation vs. SSA/ASS
             return None
 
@@ -45,9 +45,9 @@ class TmpFormat(FormatBase):
         events = []
 
         def prepare_text(text):
-            text = text.replace("|", r"\N")  # convert newlines
-            text = re.sub(r"< *u *>", "{\\\\u1}", text) # not r" for Python 2.7 compat, triggers unicodeescape
-            text = re.sub(r"< */? *[a-zA-Z][^>]*>", "", text) # strip other HTML tags
+            text = text.replace(b"|", rb"\N")  # convert newlines
+            text = re.sub(rb"< *u *>", b"{\\\\u1}", text) # not rb" for Python 2.7 compat, triggers unicodeescape
+            text = re.sub(rb"< */? *[a-zA-Z][^>]*>", b"", text) # strip other HTML tags
             return text
 
         for line in fp:
@@ -86,9 +86,9 @@ class TmpFormat(FormatBase):
             body = []
             skip = False
             for fragment, sty in parse_tags(text, style, subs.styles):
-                fragment = fragment.replace(r"\h", " ")
-                fragment = fragment.replace(r"\n", "\n")
-                fragment = fragment.replace(r"\N", "\n")
+                fragment = fragment.replace(rb"\h", b" ")
+                fragment = fragment.replace(rb"\n", b"\n")
+                fragment = fragment.replace(rb"\N", b"\n")
                 if apply_styles:
                     if sty.italic: fragment = f"<i>{fragment}</i>"
                     if sty.underline: fragment = f"<u>{fragment}</u>"
@@ -99,7 +99,7 @@ class TmpFormat(FormatBase):
             if skip:
                 return ""
             else:
-                return re.sub("\n+", "\n", "".join(body).strip())
+                return re.sub(b"\n+", b"\n", "".join(body).strip())
 
         visible_lines = (line for line in subs if not line.is_comment)
 
@@ -107,4 +107,4 @@ class TmpFormat(FormatBase):
             start = cls.ms_to_timestamp(line.start)
             text = prepare_text(line.text, subs.styles.get(line.style, SSAStyle.DEFAULT_STYLE))
 
-            print(start + ":" + text, end="\n", file=fp)
+            print(start + b":" + text, end="\n", file=fp)

--- a/pysubs2/webvtt.py
+++ b/pysubs2/webvtt.py
@@ -12,7 +12,7 @@ class WebVTTFormat(SubripFormat):
 
     Currently, this shares implementation with :class:`pysubs2.subrip.SubripFormat`.
     """
-    TIMESTAMP = re.compile(r"(\d{0,4}:)?(\d{2}):(\d{2})\.(\d{2,3})")
+    TIMESTAMP = re.compile(rb"(\d{0,4}:)?(\d{2}):(\d{2})\.(\d{2,3})")
 
     @staticmethod
     def ms_to_timestamp(ms: int) -> str:
@@ -25,14 +25,14 @@ class WebVTTFormat(SubripFormat):
         if not _h:
             h = 0
         else:
-            h = int(_h.strip(":"))
+            h = int(_h.strip(b":"))
         m, s, ms = map(int, (_m, _s, _ms))
         return make_time(h=h, m=m, s=s, ms=ms)
 
     @classmethod
     def guess_format(cls, text):
         """See :meth:`pysubs2.formats.FormatBase.guess_format()`"""
-        if text.lstrip().startswith("WEBVTT"):
+        if text.lstrip().startswith(b"WEBVTT"):
             return "vtt"
 
     @classmethod
@@ -40,7 +40,7 @@ class WebVTTFormat(SubripFormat):
         """
         See :meth:`pysubs2.formats.FormatBase.to_file()`
         """
-        print("WEBVTT\n", file=fp)
+        print(b"WEBVTT\n", file=fp)
         return super(WebVTTFormat, cls).to_file(
             subs=subs, fp=fp, format_=format_, **kwargs)
 


### PR DESCRIPTION
fix #43

simply ignore text encoding, and use raw bytestrings
dealing with text encoding is deferred to the user

this allows handling "broken" files with multiple encodings

probably this is too much change, so i merged this into [pysubs2bytes](https://github.com/milahu/pysubs2bytes)

```py
import pysubs2

subfile_path = "test.srt"

ssa_event_list = pysubs2.load(subfile_path)

for ssa_event in ssa_event_list:
    text = ssa_event.text
    if type(text) == bytes:
        text = text.decode("utf8")
    print("text", repr(text))
```
