### PR TITLE
Fix substation event default empty values

### DIFF
--- a/pysubs2/substation.py
+++ b/pysubs2/substation.py
@@ -201,7 +201,7 @@ class SubstationFormat(FormatBase):
             elif f in {"bold", "underline", "italic", "strikeout"}:
                 return v == "-1"
             elif f in {"borderstyle", "encoding", "marginl", "marginr", "marginv", "layer", "alphalevel"}:
-                return int(v)
+                return int(v) if v != "" else 0
             elif f in {"fontsize", "scalex", "scaley", "spacing", "angle", "outline", "shadow"}:
                 return float(v)
             elif f == "marked":

--- a/pysubs2/substation.py
+++ b/pysubs2/substation.py
@@ -201,7 +201,7 @@ class SubstationFormat(FormatBase):
             elif f in {"bold", "underline", "italic", "strikeout"}:
                 return v == "-1"
             elif f in {"borderstyle", "encoding", "marginl", "marginr", "marginv", "layer", "alphalevel"}:
-                return int(v) if v != "" else 0
+                return int('0'+v)
             elif f in {"fontsize", "scalex", "scaley", "spacing", "angle", "outline", "shadow"}:
                 return float(v)
             elif f == "marked":


### PR DESCRIPTION
Closes #87.

We currently try to parse the value to int assuming it is required, but it can be omitted to fallback as default as empty in the subtitles.