### PR TITLE
Fix the newline problem for tmp format

### DIFF
--- a/pysubs2/formats/tmp.py
+++ b/pysubs2/formats/tmp.py
@@ -104,7 +104,7 @@ class TmpFormat(FormatBase):
                         fragment = f"<s>{fragment}</s>"
                 body.append(fragment)
 
-            return re.sub("\n+", "\n", "".join(body).strip())
+            return re.sub("\n+", "|", "".join(body).strip())
 
         for line in subs.get_text_events():
             start = cls.ms_to_timestamp(line.start)

--- a/pysubs2/ssaevent.py
+++ b/pysubs2/ssaevent.py
@@ -25,7 +25,7 @@ class SSAEvent:
         >>> ev = SSAEvent(start=make_time(s=1), end=make_time(s=2.5), text="Hello World!")
 
     """
-    OVERRIDE_SEQUENCE: ClassVar = re.compile(r"{[^}]*}")
+    OVERRIDE_SEQUENCE: ClassVar[re.Pattern[str]] = re.compile(r"{[^}]*}")
 
     start: int = 0  #: Subtitle start time (in milliseconds)
     end: int = 10000  #: Subtitle end time (in milliseconds)

--- a/tests/formats/test_tmp.py
+++ b/tests/formats/test_tmp.py
@@ -29,13 +29,20 @@ def test_simple_write() -> None:
     e3.text = "Invisible subtitle."
     e3.is_comment = True
 
+    e4 = SSAEvent()
+    e4.start = 120000
+    e4.end = 180000
+    e4.text = "ten--chars-\nten-chars"
+
     subs.append(e1)
     subs.append(e2)
     subs.append(e3)
+    subs.append(e4)
 
     ref = dedent("""\
     00:00:00:ten--chars
     00:01:00:ten--chars-ten-chars
+    00:02:00:ten--chars-|ten-chars
     """)
 
     text = subs.to_string("tmp")
@@ -46,11 +53,13 @@ def test_simple_read() -> None:
     text = dedent("""\
     00:00:00:ten--chars
     00:01:00:ten--chars-ten-chars
+    00:02:00:ten--chars|ten-chars
     """)
     #calculate endtime from starttime + 500 miliseconds + 67 miliseconds per each character (15 chars per second)
     ref = SSAFile()
     ref.append(SSAEvent(start=0, end=make_time(ms=1840), text="ten--chars"))
     ref.append(SSAEvent(start=make_time(m=1), end=make_time(ms=62510), text="ten--chars-ten-chars"))
+    ref.append(SSAEvent(start=make_time(m=2), end=make_time(ms=122510), text="ten--chars\\Nten-chars"))
 
     subs = SSAFile.from_string(text)
     assert subs.equals(ref)


### PR DESCRIPTION
1st commit: The previous use of "\n" in to_file (saving) function causes the part after "\n" subtitles missing, and it does not agree with from_file function.

2nd commit: Added a line of subtitle with "|" as the newline for testing.

3rd commit: Added the type annotation for OVERRIDE_SEQUENCE, so that it can pass mypy test.