### PR TITLE
Fix MicroDVD writer emitting unreadable {0}{0} fps declaration

### DIFF
--- a/pysubs2/formats/microdvd.py
+++ b/pysubs2/formats/microdvd.py
@@ -120,9 +120,14 @@ class MicroDVDFormat(FormatBase):
                     return False
             return True
 
-        # insert an artificial first line telling the framerate
+        # Write an artificial first line declaring the framerate. The reader
+        # identifies it by the literal {1}{1} frame markers (see the
+        # strict_fps_inference check in from_file), so emit them directly.
+        # Routing a placeholder event through to_frames() instead would
+        # convert its 1 ms start/end to frame 0 for any realistic fps, writing
+        # an unreadable {0}{0} line (it only worked for fps == 1000).
         if write_fps_declaration:
-            subs.insert(0, SSAEvent(start=1, end=1, text=str(fps)))
+            print("{1}{1}%s" % fps, file=fp)
 
         for line in subs.get_text_events():
             text = "|".join(line.plaintext.splitlines())
@@ -138,7 +143,3 @@ class MicroDVDFormat(FormatBase):
                 end = 0
 
             print("{%d}{%d}%s" % (start, end, text), file=fp)
-
-        # remove the artificial framerate-telling line
-        if write_fps_declaration:
-            subs.pop(0)

--- a/tests/formats/test_microdvd.py
+++ b/tests/formats/test_microdvd.py
@@ -209,3 +209,36 @@ def test_write_drawing() -> None:
     """)
 
     assert subs.to_string("microdvd", fps=1000) == f
+
+
+@pytest.mark.parametrize("fps", [23.976, 24.0, 25.0, 29.97, 30.0, 48.0, 60.0])
+def test_writer_fps_declaration_uses_frame_one(fps: float) -> None:
+    # The fps-declaration line must carry the literal {1}{1} frame markers for
+    # every framerate, not only fps == 1000. It used to be built from a 1 ms
+    # placeholder event run through ms_to_frames(), which rounds down to frame
+    # 0 for any realistic fps, writing an unreadable {0}{0} line.
+    subs = SSAFile()
+    subs.append(SSAEvent(start=0, end=2000, text="Hello!"))
+
+    out = subs.to_string("microdvd", fps=fps)
+    assert out.splitlines()[0] == "{1}{1}%s" % fps
+
+    # The output must round-trip through the default (strict) reader: the fps
+    # is inferred from the declaration and the event survives unchanged.
+    back = SSAFile.from_string(out, format_="microdvd")
+    assert back.fps == fps
+    assert len(back) == 1
+    assert back[0].plaintext == "Hello!"
+
+
+def test_writer_does_not_mutate_input() -> None:
+    # Writing must not leave the artificial fps-declaration event behind in
+    # the caller's subtitle list (the writer used to insert(0, ...)/pop(0)).
+    subs = SSAFile()
+    subs.append(SSAEvent(start=0, end=2000, text="Hello!"))
+    subs.append(SSAEvent(start=2000, end=4000, text="World!"))
+    before = list(subs.events)
+
+    subs.to_string("microdvd", fps=25.0)
+
+    assert subs.events == before


### PR DESCRIPTION
### The bug

The MicroDVD writer emits an fps-declaration line that pysubs2's own default reader rejects, for every realistic framerate:

```python
import pysubs2
from pysubs2 import SSAFile, SSAEvent

subs = SSAFile()
subs.append(SSAEvent(start=0, end=2000, text="First line"))

out = subs.to_string("microdvd", fps=23.976)
out.splitlines()[0]                              # '{0}{0}23.976'   <-- should be {1}{1}
SSAFile.from_string(out, format_="microdvd")     # raises UnknownFPSError
```

The declaration line is written as `{0}{0}<fps>` instead of `{1}{1}<fps>` for 24, 25, 29.97, 30, 48, 60 — essentially every real framerate. Reading the file back with the default reader then fails with `UnknownFPSError`, because the reader requires the `{1}{1}` frame markers (`strict_fps_inference=True` by default).

That `{1}{1}` is the documented contract: the writer's own docstring says it creates *"a zero-duration first subtitle `{1}{1}` which will contain the fps"*, and issue #71 fixed the reader to only accept fps from a `{1}{1}` line.

### Root cause

`pysubs2/formats/microdvd.py`, in `to_file()`:

```python
if write_fps_declaration:
    subs.insert(0, SSAEvent(start=1, end=1, text=str(fps)))   # start/end are MILLISECONDS
...
    start, end = map(to_frames, (line.start, line.end))       # ms_to_frames(1, fps)
```

The placeholder event's `start`/`end` are **1 millisecond**, but they're then run through `ms_to_frames(1, fps)` like a normal event. `ms_to_frames(1, fps)` rounds 1 ms down to frame **0** for any fps below ~750, so the marker comes out as `{0}{0}`. It only lands on frame 1 when `fps == 1000` — which is the value **every** existing MicroDVD writer test uses, so the bug was never caught. "Frame 1" and "1 millisecond" were conflated.

### The fix

Write the `{1}{1}<fps>` declaration line literally rather than synthesising a 1 ms placeholder event and routing it through the frame conversion. As a side benefit this drops the `insert(0, ...)`/`pop(0)` pair, so writing no longer mutates the caller's event list.

```python
if write_fps_declaration:
    print("{1}{1}%s" % fps, file=fp)
```

For `fps == 1000` the output is byte-identical to before, so the existing tests are unchanged.

### Tests

`test_writer_fps_declaration_uses_frame_one` is parametrized over seven realistic framerates and asserts both that the first line is `{1}{1}<fps>` and that the output round-trips back through the **default (strict)** reader with the fps detected and the event intact. It fails on `master` for all seven and passes with the fix. A `test_writer_does_not_mutate_input` guards the no-side-effect property. Full suite: 137 passed; `mypy --strict` and `ruff check` clean.
