### PR TITLE
Preserve bold styling when writing SubRip/WebVTT

### DIFF
--- a/pysubs2/formats/subrip.py
+++ b/pysubs2/formats/subrip.py
@@ -125,7 +125,7 @@ class SubripFormat(FormatBase):
         """
         See :meth:`pysubs2.formats.FormatBase.to_file()`
 
-        Italic, underline and strikeout styling is supported.
+        Italic, bold, underline and strikeout styling is supported.
 
         Keyword args:
             apply_styles: If False, do not write any styling (ignore line style
@@ -156,6 +156,8 @@ class SubripFormat(FormatBase):
                     if apply_styles:
                         if sty.italic:
                             fragment = f"<i>{fragment}</i>"
+                        if sty.bold:
+                            fragment = f"<b>{fragment}</b>"
                         if sty.underline:
                             fragment = f"<u>{fragment}</u>"
                         if sty.strikeout:

--- a/tests/formats/test_subrip.py
+++ b/tests/formats/test_subrip.py
@@ -223,6 +223,55 @@ def test_keep_unknown_html_tags() -> None:
     assert subs_keep.to_string("srt") == ref_keep.to_string("srt")
 
 
+def test_write_bold() -> None:
+    # SubRip supports <b> and the reader converts it to the {\\b1} override tag
+    # (see test_read_tags), but the writer used to drop bold styling entirely,
+    # silently losing formatting on load -> save round-trips.
+    subs = SSAFile()
+    subs.append(SSAEvent(start=0, end=60000, text=r"{\b1}Bold text{\b0}"))
+
+    ref = dedent("""\
+    1
+    00:00:00,000 --> 00:01:00,000
+    <b>Bold text</b>
+    """)
+
+    assert subs.to_string("srt").strip() == ref.strip()
+
+
+def test_bold_round_trip() -> None:
+    text = dedent("""\
+    1
+    00:00:00,000 --> 00:01:00,000
+    <b>Bold</b> and plain
+    """)
+
+    ref = SSAFile()
+    ref.append(SSAEvent(start=0, end=make_time(m=1), text=r"{\b1}Bold{\b0} and plain"))
+
+    subs = SSAFile.from_string(text)
+    assert subs.equals(ref)
+
+    # bold must survive being written back out ...
+    output = subs.to_string("srt")
+    assert "<b>Bold</b>" in output
+
+    # ... and the whole load -> save -> load cycle must be lossless
+    reparsed = SSAFile.from_string(output)
+    assert reparsed.equals(ref)
+    assert reparsed.to_string("srt") == output
+
+
+def test_write_all_inline_styles() -> None:
+    # bold, italic, underline and strikeout should all be preserved together
+    subs = SSAFile()
+    subs.append(SSAEvent(start=0, end=60000,
+                         text=r"{\b1}b{\b0} {\i1}i{\i0} {\u1}u{\u0} {\s1}s{\s0}"))
+
+    output_line = subs.to_string("srt").splitlines()[2]
+    assert output_line == "<b>b</b> <i>i</i> <u>u</u> <s>s</s>"
+
+
 def test_write_drawing() -> None:
     # test for 7bde9a6c3a250cf0880a8a9fe31d1b6a69ff21a0
     subs = SSAFile()

--- a/tests/formats/test_vtt.py
+++ b/tests/formats/test_vtt.py
@@ -80,6 +80,28 @@ def test_writes_in_time_order() -> None:
     assert text.strip() == ref.strip()
 
 
+def test_bold_round_trip() -> None:
+    # WebVTT reuses the SubRip writer, which used to drop bold styling;
+    # <b> is valid WebVTT markup and must survive a load -> save round-trip.
+    text = dedent("""\
+    WEBVTT
+
+    1
+    00:00:00.000 --> 00:01:00.000
+    <b>Bold</b> and plain
+    """)
+
+    ref = SSAFile()
+    ref.append(SSAEvent(start=0, end=make_time(m=1), text=r"{\b1}Bold{\b0} and plain"))
+
+    subs = SSAFile.from_string(text)
+    assert subs.equals(ref)
+
+    output = subs.to_string("vtt")
+    assert "<b>Bold</b>" in output
+    assert SSAFile.from_string(output).equals(ref)
+
+
 def test_simple_read() -> None:
     text = dedent("""\
     WEBVTT


### PR DESCRIPTION
## Problem

The SubRip writer (`SubripFormat.to_file`, also used for WebVTT) converts style flags back into HTML tags when serialising, but it only handled italic, underline and strikeout — **bold was dropped**.

The reader already maps `<b>...</b>` to the `{\b1}...{\b0}` override, so a simple load → save round-trip silently loses bold:

```python
subs = SSAFile.from_string("1\n00:00:00,000 --> 00:01:00,000\n<b>Bold</b>\n")
subs.to_string("srt")   # -> "...\nBold\n"  (bold gone)
```

`<b>` is valid markup in both SubRip and WebVTT, and bold is a first-class style flag on `SSAStyle`/`SSAEvent`, so this is an asymmetry between read and write rather than an intentional limitation.

## Fix

Emit `<b>` alongside the other inline tags in the writer, mirroring the existing italic/underline/strikeout branches. Since WebVTT reuses this writer, it is covered too.

## Tests

- `test_write_bold` / `test_write_all_inline_styles` — bold is written, and all four inline styles serialise together.
- `test_bold_round_trip` (SubRip and WebVTT) — `<b>` survives a full load → save → load cycle losslessly.
